### PR TITLE
#4 [feat] :sparkles: 作成したmarkdownをリポジトリにも保存できるようにする

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -32,6 +32,9 @@
       "recommended": true,
       "correctness": {
         "noUnusedImports": "error"
+      },
+      "complexity": {
+        "noForEach": "off"
       }
     }
   }

--- a/src/app/_hooks/useMicroCms.ts
+++ b/src/app/_hooks/useMicroCms.ts
@@ -12,6 +12,7 @@ type Message<T> = {
 type UseMicroCmsReturns<T> = {
   iframeId: string
   data: T | undefined
+  message: Message<T> | undefined
   sendMessage: (message: Message<T>) => void
 }
 
@@ -19,14 +20,15 @@ const origin = process.env.NEXT_PUBLIC_MICROCMS_ORIGIN || ""
 
 export const useMicroCms = <T>(): UseMicroCmsReturns<T> => {
   const [iframeId, setIframeId] = useState<string>("")
-  const [data, setData] = useState<T | undefined>()
+  const [message, setMessage] = useState<Message<T> | undefined>()
+  const data = message?.data
 
   const listener = useCallback((event: MessageEvent) => {
     if (!event.isTrusted) return
     if (event.data.action === "MICROCMS_GET_DEFAULT_DATA") {
       setIframeId(event.data.id)
       if (event.data.message) {
-        setData(event.data.message.data)
+        setMessage(event.data.message)
       }
     }
   }, [])
@@ -55,7 +57,7 @@ export const useMicroCms = <T>(): UseMicroCmsReturns<T> => {
 
   const sendMessage = useCallback(
     (message: Message<T>) => {
-      setData(message.data)
+      setMessage(message)
       window.parent.postMessage(
         {
           id: iframeId,
@@ -71,5 +73,5 @@ export const useMicroCms = <T>(): UseMicroCmsReturns<T> => {
     [iframeId],
   )
 
-  return { iframeId, data, sendMessage }
+  return { iframeId, data, message, sendMessage }
 }

--- a/src/app/api/markdown/route.ts
+++ b/src/app/api/markdown/route.ts
@@ -1,0 +1,16 @@
+import { createMarkdown } from "@/utils/fs"
+
+export const dynamic = 'force-dynamic'
+export const GET = async (request: Request) => {
+  const { searchParams } = new URL(request.url)
+  const query = searchParams.get('query')
+  return Response.json({ message: `GET: ${query}` })
+}
+
+export const POST = async (request: Request) => {
+  const body = await request.json()
+  const result = createMarkdown(body.filename, body.markdown)
+  const responseBody = result ? 'success' : 'failed'
+  const status = result ? 200 : 500
+  return new Response(responseBody, { status })
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from "react"
 import "@uiw/react-md-editor/markdown-editor.css"
 import "@uiw/react-markdown-preview/markdown.css"
 import { useMicroCms } from "./_hooks/useMicroCms"
+import { request } from "@/utils/internal-api"
+import type { CreateMarkdownRequest } from "@/types/api/create-markdown"
 
 const MDEditor = dynamic(() => import("@uiw/react-md-editor"), {
   ssr: false,
@@ -12,29 +14,57 @@ const MDEditor = dynamic(() => import("@uiw/react-md-editor"), {
 
 const MarkdownEditor = () => {
   const [markdown, setMarkdown] = useState<string | undefined>()
-  const { data, sendMessage } = useMicroCms<string | undefined>()
+  const [filename, setFilename] = useState<string>("")
+  const { data, message, sendMessage } = useMicroCms<string | undefined>()
+
+  const createMarkdownRequest = async () => {
+    await request<CreateMarkdownRequest>({
+      url: "/api/markdown",
+      method: "POST",
+      body: {
+        filename: filename,
+        markdown: markdown,
+      },
+    })
+  }
 
   useEffect(() => {
     if (!markdown) {
       setMarkdown(data)
     }
-  }, [data, markdown])
+    if (!filename && message?.title) {
+      setFilename(message?.title)
+    }
+  }, [data, markdown, message, filename])
+
+  const handleInput = (title: string, markdown: string | undefined) => {
+    setFilename(title)
+    setMarkdown(markdown)
+    sendMessage({
+      title: title,
+      data: markdown,
+    })
+  }
 
   return (
     <div data-color-mode="light">
+      <label>Filename:</label>
+      <input
+        type="text"
+        value={filename}
+        onChange={(e) => handleInput(e.target.value, markdown)}
+      />
       <MDEditor
         value={markdown}
-        onChange={(value) => {
-          setMarkdown(value)
-          sendMessage({
-            data: value,
-          })
-        }}
+        onChange={(value) => handleInput(filename, value)}
         height={540}
         textareaProps={{
           placeholder: "Please enter Markdown text",
         }}
       />
+      <button type="button" onClick={createMarkdownRequest}>
+        Save
+      </button>
     </div>
   )
 }

--- a/src/types/api/create-markdown.ts
+++ b/src/types/api/create-markdown.ts
@@ -1,0 +1,4 @@
+export type CreateMarkdownRequest = {
+  filename: string
+  markdown: string | undefined
+}

--- a/src/types/blog.ts
+++ b/src/types/blog.ts
@@ -1,0 +1,13 @@
+import type { Category } from "./category"
+import type { Tag } from "./tag"
+
+export type Blog = {
+  id: string
+  title: string
+  createdAt: string
+  updatedAt: string
+  publishedAt: string
+  markdown: string
+  category: Category
+  tags: Tag[]
+}

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -1,0 +1,8 @@
+export type Category = {
+  id: string
+  name: string
+  createdAt: string
+  updatedAt: string
+  publishedAt: string
+  revisedAt: string
+}

--- a/src/types/tag.ts
+++ b/src/types/tag.ts
@@ -1,0 +1,8 @@
+export type Tag = {
+  id: string
+  name: string
+  createdAt: string
+  updatedAt: string
+  publishedAt: string
+  revisedAt: string
+}

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,0 +1,19 @@
+import fs from "node:fs"
+import { join } from "node:path"
+
+const postsDirectory = join(process.cwd(), "src/posts")
+export const createMarkdown = (filename: string, markdown: string): boolean => {
+  const dirPath = `${postsDirectory}/${filename}`
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true })
+    console.log(`Directory ${dirPath} created.`)
+  }
+
+  try {
+    fs.writeFileSync(`${dirPath}/${filename}.md`, markdown)
+    return true
+  } catch (error) {
+    console.error(error)
+    return false
+  }
+}

--- a/src/utils/internal-api.ts
+++ b/src/utils/internal-api.ts
@@ -1,0 +1,22 @@
+type Method = "GET" | "POST" | "PUT" | "DELETE"
+type RequestArgs<T> = {
+  url: string
+  method: Method
+  params?: { [key: string]: string }
+  body?: T
+}
+export const request = async <T>({url, method, params, body }: RequestArgs<T>): Promise<Response> => {
+  const headers = {
+    "Content-Type": "application/json",
+  }
+  if (params) {
+    const searchParams = new URLSearchParams(params)
+    url += `?${searchParams.toString()}`
+  }
+  const requestBody = body ? JSON.stringify(body) : undefined
+  return await fetch(url, {
+    method: method,
+    headers: headers,
+    body: requestBody,
+  })
+}


### PR DESCRIPTION
## 内容
- iframe経由で編集しているmarkdownをリポジトリの`src/posts/${title}/${title}.md`にも保存できるようにする
  - 埋め込みデータも管理する想定でフォルダを切っている
- 簡単にnode上での処理をさせることができそうだったので、[Route Handlers](https://nextjs.org/docs/app/building-your-application/routing/route-handlers)を使ってみる
- メタ情報もファイルに入れるためには、microCMSからデータを取得する必要があるが未実装

close #4